### PR TITLE
Replace exploitable EWR-Salewa barter & remove medkit crafts

### DIFF
--- a/src/db/hideout.ts
+++ b/src/db/hideout.ts
@@ -1,0 +1,6 @@
+export const medkitCraftsToRemove = [
+    "5d8a1a7d7a3dfe597c2e459e", // Salewa
+    "5d5c21aed582a50066024610", // IFAK
+    "615c3d27966c85458e4c49cf", // AFAK
+    "5d78d8a03fe9fc21602e16be" // Grizzly
+]

--- a/src/db/itemCfg.ts
+++ b/src/db/itemCfg.ts
@@ -1,11 +1,11 @@
+import type { Prefab, Props } from "@spt/models/eft/common/tables/ITemplateItem";
 import type { IBarterScheme } from "@spt/models/eft/common/tables/ITrader";
 import { BaseClasses } from "@spt/models/enums/BaseClasses";
 import { ItemTpl } from "@spt/models/enums/ItemTpl";
 import { Money } from "@spt/models/enums/Money";
 import { Traders } from "@spt/models/enums/Traders";
-import { CustomMedkitItemTpl, CustomNewItemTpl, type OriginalItemTpl } from "./types/Item";
-import type { Prefab, Props } from "@spt/models/eft/common/tables/ITemplateItem";
-import { ModNames } from "./types/AppTypes";
+import { ModNames } from "../utils/types/AppTypes";
+import { CustomMedkitItemTpl, CustomNewItemTpl, type OriginalItemTpl } from "../utils/types/Item";
 
 const handbookMedkitsId = "5b47574386f77428ca22b338";
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -56,7 +56,7 @@ class CustomFirstAidKits implements IPostDBLoadMod, IPreSptLoadMod
         this.replaceBaseItems = this.cfakCfg.replaceBaseItems;
 
         this.setModFlags(preSptModLoader);
-        
+
         const customBotLootGenerator = new CustomBotLootGenerator(
             sptLogger,
             hashUtil,
@@ -76,7 +76,10 @@ class CustomFirstAidKits implements IPostDBLoadMod, IPreSptLoadMod
             this.cfakCfg,
             this.logger
         )
-        
+            
+        // Extend loot generator to make bots spawn with items in medkits
+        // Note we don't add the new medkits to the loot pool, so if replaceBaseItems is false, the new medkits won't spawn (unless something else adds the items in loot pool)
+        // With replaceBaseItems = true, the medkits use the original IDs so will spawn on bots
         container.afterResolution<BotLootGenerator>(
             "BotLootGenerator",
             (_token, botLootGen: BotLootGenerator) => 
@@ -85,6 +88,7 @@ class CustomFirstAidKits implements IPostDBLoadMod, IPreSptLoadMod
             }, { frequency: "Always" }
         );
         this.logger.log("Updated loot generator to include custom containers!");
+        
     }
 
     public postDBLoad(container: DependencyContainer): void 
@@ -95,9 +99,10 @@ class CustomFirstAidKits implements IPostDBLoadMod, IPreSptLoadMod
 
         ItemFactory.init(container);
         const itemFactory = new ItemFactory(this.cfakCfg, this.logger, this.modFlags);
+
         itemFactory.createBloodbag();
         itemFactory.createMedkits();
-        this.logger.log("Items added!");
+        this.logger.log("Finished initializing!");
     }
 
     // Get mods we need to run compatibility stuff for

--- a/src/utils/CustomBotLootGenerator.ts
+++ b/src/utils/CustomBotLootGenerator.ts
@@ -1,31 +1,28 @@
 import { BotLootGenerator } from "@spt/generators/BotLootGenerator";
+import type { BotWeaponGenerator } from "@spt/generators/BotWeaponGenerator";
+import type { BotGeneratorHelper } from "@spt/helpers/BotGeneratorHelper";
+import type { BotHelper } from "@spt/helpers/BotHelper";
+import type { HandbookHelper } from "@spt/helpers/HandbookHelper";
+import type { InventoryHelper } from "@spt/helpers/InventoryHelper";
+import type { ItemHelper } from "@spt/helpers/ItemHelper";
+import type { WeightedRandomHelper } from "@spt/helpers/WeightedRandomHelper";
 import type { Inventory } from "@spt/models/eft/common/tables/IBotBase";
 import type { IBotType } from "@spt/models/eft/common/tables/IBotType";
 import type { Item } from "@spt/models/eft/common/tables/IItem";
 import type { ITemplateItem } from "@spt/models/eft/common/tables/ITemplateItem";
-import { CustomMedkitItemTpl, customToOriginalMap, OriginalMedkitItemTpl } from "./types/Item";
-import type { BotLootCacheService } from "@spt/services/BotLootCacheService";
 import type { ILogger } from "@spt/models/spt/utils/ILogger";
+import type { ConfigServer } from "@spt/servers/ConfigServer";
+import type { BotLootCacheService } from "@spt/services/BotLootCacheService";
+import type { DatabaseService } from "@spt/services/DatabaseService";
+import type { LocalisationService } from "@spt/services/LocalisationService";
 import type { HashUtil } from "@spt/utils/HashUtil";
 import type { RandomUtil } from "@spt/utils/RandomUtil";
-import type { ItemHelper } from "@spt/helpers/ItemHelper";
-import type { InventoryHelper } from "@spt/helpers/InventoryHelper";
-import type { DatabaseService } from "@spt/services/DatabaseService";
-import type { HandbookHelper } from "@spt/helpers/HandbookHelper";
-import type { BotGeneratorHelper } from "@spt/helpers/BotGeneratorHelper";
-import type { BotWeaponGenerator } from "@spt/generators/BotWeaponGenerator";
-import type { WeightedRandomHelper } from "@spt/helpers/WeightedRandomHelper";
-import type { BotHelper } from "@spt/helpers/BotHelper";
-import type { LocalisationService } from "@spt/services/LocalisationService";
-import type { ConfigServer } from "@spt/servers/ConfigServer";
 import type { ICloner } from "@spt/utils/cloners/ICloner";
-import type CfakConfig from "./types/CfakConfig";
-import itemCfg, { type ItemCfgInfo } from "./itemCfg";
+import itemCfg, { type ItemCfgInfo } from "../db/itemCfg";
 import GridHelper from "./GridHelper";
 import type Logger from "./Logger";
-import { LootCacheType } from "@spt/models/spt/bots/IBotLootCache";
-import { EquipmentSlots } from "@spt/models/enums/EquipmentSlots";
-import { ItemAddedResult } from "@spt/models/enums/ItemAddedResult";
+import type CfakConfig from "./types/CfakConfig";
+import { CustomMedkitItemTpl, OriginalMedkitItemTpl, customToOriginalMap } from "./types/Item";
 
 export default class CustomBotLootGenerator extends BotLootGenerator 
 {

--- a/src/utils/GridHelper.ts
+++ b/src/utils/GridHelper.ts
@@ -1,5 +1,5 @@
 import type { Item } from "@spt/models/eft/common/tables/IItem";
-import type { ItemCfgInfo } from "./itemCfg";
+import type { ItemCfgInfo } from "../db/itemCfg";
 import type { HashUtil } from "@spt/utils/HashUtil";
 import type Logger from "./Logger";
 import { LoggerLvl } from "./Logger";

--- a/src/utils/itemCfg.ts
+++ b/src/utils/itemCfg.ts
@@ -29,7 +29,7 @@ export interface ItemCfgInfo
     bundled?: ItemTpl[];
     bundlePrice?: number;
     currency: Money;
-    customBarter?: IBarterScheme[][];
+    customBarter?: { always: boolean; scheme: IBarterScheme[][]};
     soldBy: Traders;
     loyalLevel: {
         buy: number,
@@ -44,7 +44,8 @@ export interface ItemCfgInfo
     itemSound?: string;
     backgroundColor?: string;
     handbookParent: string;
-    otherProps?: Props & { overrides?: Record<ModNames, Props> }
+    otherProps?: Props & { overrides?: Record<ModNames, Props> };
+    deleteBarters?: string[];
 }
 
 export type ItemCfg = Record<OriginalItemTpl | CustomNewItemTpl, ItemCfgInfo>;
@@ -162,19 +163,20 @@ const itemCfg: ItemCfg = {
         bundled: [ItemTpl.MEDICAL_ARMY_BANDAGE, ItemTpl.MEDICAL_ASEPTIC_BANDAGE, ItemTpl.MEDICAL_ESMARCH_TOURNIQUET, ItemTpl.MEDICAL_CALOKB_HEMOSTATIC_APPLICATOR, ItemTpl.DRINK_EMERGENCY_WATER_RATION],
         bundlePrice: 39420,
         currency: Money.ROUBLES,
-        // customBarter: [
-        //     [
-        //         {
-        //             _tpl: ItemTpl.BARTER_BOTTLE_OF_SALINE_SOLUTION,
-        //             count: 2
-        //         }
-        //     ]
-        // ],
+        customBarter: { always: true, scheme: [
+            [
+                {
+                    _tpl: ItemTpl.BARTER_PILE_OF_MEDS,
+                    count: 1
+                }
+            ]
+        ]},
         soldBy: Traders.THERAPIST,
         loyalLevel: {
-            buy: 2
-            // barter: 2
-        }
+            buy: 2,
+            barter: 1
+        },
+        deleteBarters: ["666aa327e8e00edadd0d24b5"] // EWR barter
     }),
     [ItemTpl.MEDKIT_IFAK_INDIVIDUAL_FIRST_AID_KIT]: createMedkitDetails({
         idForNewItem: CustomMedkitItemTpl.IFAK_FIST_AID_KIT,
@@ -201,14 +203,14 @@ const itemCfg: ItemCfg = {
         bundled: [ItemTpl.MEDICAL_ARMY_BANDAGE, ItemTpl.MEDICAL_CALOKB_HEMOSTATIC_APPLICATOR, ItemTpl.MEDICAL_CAT_HEMOSTATIC_TOURNIQUET],
         bundlePrice: 50000,
         currency: Money.ROUBLES,
-        customBarter: [
+        customBarter: { always: false, scheme: [
             [
                 {
                     _tpl: ItemTpl.BARTER_BOTTLE_OF_SALINE_SOLUTION,
                     count: 2
                 }
             ]
-        ],
+        ]},
         soldBy: Traders.THERAPIST,
         loyalLevel: {
             buy: 3,


### PR DESCRIPTION
## Description

There is a Therapist barter to give 1 EWR for 1 Salewa. Since Salewas come with EWR inside, you could get free Salewas with this. It has been replaced with a pile of meds barter.

The hideout crafts for medkits have been removed when replacing base medkits, as with this mod you would end up getting an empty medkit in exchange for some bandages. The crafts are still valid when not replacing base items so we keep them in that case.

## Changes
- Replaced EWR Salewa trade with pile of meds trade
- Added ability to delete barters
- Can now force custom barters to always be added (regardless of replaceBaseItems value)
- Removed hideout medkit crafts when replacing base items
- Moved itemCfg to db folder

## Followup
- Could be possible to have hideout crafts return a container containing items, similar to how we allow traders to sell bundles. If so, we could add back sensible crafts for medkits